### PR TITLE
Update Nuke: 12.8

### DIFF
--- a/ios101-lab7-flix.xcodeproj/project.pbxproj
+++ b/ios101-lab7-flix.xcodeproj/project.pbxproj
@@ -9,7 +9,6 @@
 /* Begin PBXBuildFile section */
 		ED4DC9B329C7FB8300DFE47B /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED4DC9B229C7FB8300DFE47B /* DetailViewController.swift */; };
 		ED83EE9A29B05FCE007A4FC9 /* Movie.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED83EE9929B05FCE007A4FC9 /* Movie.swift */; };
-		ED83EE9D29B06A4C007A4FC9 /* Nuke in Frameworks */ = {isa = PBXBuildFile; productRef = ED83EE9C29B06A4C007A4FC9 /* Nuke */; };
 		ED83EEA129B71218007A4FC9 /* MovieCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED83EEA029B71218007A4FC9 /* MovieCell.swift */; };
 		ED88ABF229AD9858008A6FF6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED88ABF129AD9858008A6FF6 /* AppDelegate.swift */; };
 		ED88ABF429AD9858008A6FF6 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED88ABF329AD9858008A6FF6 /* SceneDelegate.swift */; };
@@ -17,6 +16,10 @@
 		ED88ABF929AD9858008A6FF6 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = ED88ABF729AD9858008A6FF6 /* Main.storyboard */; };
 		ED88ABFB29AD9859008A6FF6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = ED88ABFA29AD9859008A6FF6 /* Assets.xcassets */; };
 		ED88ABFE29AD9859008A6FF6 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = ED88ABFC29AD9859008A6FF6 /* LaunchScreen.storyboard */; };
+		EDDD50662DC41BCA00B71C96 /* Nuke in Frameworks */ = {isa = PBXBuildFile; productRef = EDDD50652DC41BCA00B71C96 /* Nuke */; };
+		EDDD50682DC41BCA00B71C96 /* NukeExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = EDDD50672DC41BCA00B71C96 /* NukeExtensions */; };
+		EDDD506A2DC41BCA00B71C96 /* NukeUI in Frameworks */ = {isa = PBXBuildFile; productRef = EDDD50692DC41BCA00B71C96 /* NukeUI */; };
+		EDDD506C2DC41BCA00B71C96 /* NukeVideo in Frameworks */ = {isa = PBXBuildFile; productRef = EDDD506B2DC41BCA00B71C96 /* NukeVideo */; };
 		EDEA510A29EF939A0087372A /* FavoritesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDEA510929EF939A0087372A /* FavoritesViewController.swift */; };
 /* End PBXBuildFile section */
 
@@ -40,7 +43,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				ED83EE9D29B06A4C007A4FC9 /* Nuke in Frameworks */,
+				EDDD506A2DC41BCA00B71C96 /* NukeUI in Frameworks */,
+				EDDD50662DC41BCA00B71C96 /* Nuke in Frameworks */,
+				EDDD50682DC41BCA00B71C96 /* NukeExtensions in Frameworks */,
+				EDDD506C2DC41BCA00B71C96 /* NukeVideo in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -98,7 +104,10 @@
 			);
 			name = "ios101-lab7-flix";
 			packageProductDependencies = (
-				ED83EE9C29B06A4C007A4FC9 /* Nuke */,
+				EDDD50652DC41BCA00B71C96 /* Nuke */,
+				EDDD50672DC41BCA00B71C96 /* NukeExtensions */,
+				EDDD50692DC41BCA00B71C96 /* NukeUI */,
+				EDDD506B2DC41BCA00B71C96 /* NukeVideo */,
 			);
 			productName = "ios101-lab5-flix1";
 			productReference = ED88ABEE29AD9858008A6FF6 /* ios101-lab7-flix.app */;
@@ -129,7 +138,7 @@
 			);
 			mainGroup = ED88ABE529AD9858008A6FF6;
 			packageReferences = (
-				ED83EE9B29B06A4C007A4FC9 /* XCRemoteSwiftPackageReference "Nuke" */,
+				EDDD50642DC41BCA00B71C96 /* XCRemoteSwiftPackageReference "Nuke" */,
 			);
 			productRefGroup = ED88ABEF29AD9858008A6FF6 /* Products */;
 			projectDirPath = "";
@@ -382,21 +391,36 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		ED83EE9B29B06A4C007A4FC9 /* XCRemoteSwiftPackageReference "Nuke" */ = {
+		EDDD50642DC41BCA00B71C96 /* XCRemoteSwiftPackageReference "Nuke" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/kean/Nuke";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 9.0.0;
+				minimumVersion = 12.8.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		ED83EE9C29B06A4C007A4FC9 /* Nuke */ = {
+		EDDD50652DC41BCA00B71C96 /* Nuke */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = ED83EE9B29B06A4C007A4FC9 /* XCRemoteSwiftPackageReference "Nuke" */;
+			package = EDDD50642DC41BCA00B71C96 /* XCRemoteSwiftPackageReference "Nuke" */;
 			productName = Nuke;
+		};
+		EDDD50672DC41BCA00B71C96 /* NukeExtensions */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = EDDD50642DC41BCA00B71C96 /* XCRemoteSwiftPackageReference "Nuke" */;
+			productName = NukeExtensions;
+		};
+		EDDD50692DC41BCA00B71C96 /* NukeUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = EDDD50642DC41BCA00B71C96 /* XCRemoteSwiftPackageReference "Nuke" */;
+			productName = NukeUI;
+		};
+		EDDD506B2DC41BCA00B71C96 /* NukeVideo */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = EDDD50642DC41BCA00B71C96 /* XCRemoteSwiftPackageReference "Nuke" */;
+			productName = NukeVideo;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/ios101-lab7-flix.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios101-lab7-flix.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,14 +1,15 @@
 {
+  "originHash" : "8db810839d2e05d8fa43fe72481467e8e9f47bda8dad613e17d2b9a570e27109",
   "pins" : [
     {
       "identity" : "nuke",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kean/Nuke",
       "state" : {
-        "revision" : "7f73ceaeacd5df75a7994cd82e165ad9ff1815db",
-        "version" : "9.6.1"
+        "revision" : "0ead44350d2737db384908569c012fe67c421e4d",
+        "version" : "12.8.0"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/ios101-lab7-flix/DetailViewController.swift
+++ b/ios101-lab7-flix/DetailViewController.swift
@@ -4,7 +4,7 @@
 //
 
 import UIKit
-import Nuke
+import NukeExtensions
 
 class DetailViewController: UIViewController {
 
@@ -87,7 +87,7 @@ class DetailViewController: UIViewController {
            let imageUrl = URL(string: "https://image.tmdb.org/t/p/w500" + posterPath) {
 
             // Use the Nuke library's load image function to (async) fetch and load the image from the image url.
-            Nuke.loadImage(with: imageUrl, into: posterImageView)
+            NukeExtensions.loadImage(with: imageUrl, into: posterImageView)
         }
 
         // Unwrap the optional backdrop path
@@ -97,7 +97,7 @@ class DetailViewController: UIViewController {
            let imageUrl = URL(string: "https://image.tmdb.org/t/p/w500" + backdropPath) {
 
             // Use the Nuke library's load image function to (async) fetch and load the image from the image url.
-            Nuke.loadImage(with: imageUrl, into: backdropImageView)
+            NukeExtensions.loadImage(with: imageUrl, into: backdropImageView)
         }
     }
 

--- a/ios101-lab7-flix/FavoritesViewController.swift
+++ b/ios101-lab7-flix/FavoritesViewController.swift
@@ -4,7 +4,7 @@
 //
 
 import UIKit
-import Nuke
+import NukeExtensions
 
 class FavoritesViewController: UIViewController, UITableViewDataSource {
 
@@ -53,7 +53,7 @@ class FavoritesViewController: UIViewController, UITableViewDataSource {
            let imageUrl = URL(string: "https://image.tmdb.org/t/p/w500" + posterPath) {
 
             // Use the Nuke library's load image function to (async) fetch and load the image from the image url.
-            Nuke.loadImage(with: imageUrl, into: cell.posterImageView)
+            NukeExtensions.loadImage(with: imageUrl, into: cell.posterImageView)
         }
 
         // Set the text on the labels

--- a/ios101-lab7-flix/FeedViewController.swift
+++ b/ios101-lab7-flix/FeedViewController.swift
@@ -4,7 +4,7 @@
 //
 
 import UIKit
-import Nuke
+import NukeExtensions
 
 // Add table view data source conformance
 class FeedViewController: UIViewController, UITableViewDataSource {
@@ -66,7 +66,7 @@ class FeedViewController: UIViewController, UITableViewDataSource {
            let imageUrl = URL(string: "https://image.tmdb.org/t/p/w500" + posterPath) {
 
             // Use the Nuke library's load image function to (async) fetch and load the image from the image url.
-            Nuke.loadImage(with: imageUrl, into: cell.posterImageView)
+            NukeExtensions.loadImage(with: imageUrl, into: cell.posterImageView)
         }
 
         // Set the text on the labels


### PR DESCRIPTION
### Description

The latest Nuke version has migrated the `loadImage(with:into:)` function from `Nuke` to `NukeExtensions`. The only change from a usage standpoint is using `NukeExtensions` on `import` and when calling the related loadImage function.

```
import NukeExtensions
...

NukeExtensions.loadImage(with: url, into: imageView)
```